### PR TITLE
게시글 조회 시 slice 방식의 페이징 처리 추가

### DIFF
--- a/src/main/java/site/practice/controller/ArticleController.java
+++ b/src/main/java/site/practice/controller/ArticleController.java
@@ -1,6 +1,9 @@
 package site.practice.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +21,6 @@ import site.practice.dto.GetArticlesResponseDto;
 import site.practice.dto.UpdateArticleRequestDto;
 import site.practice.entity.Article;
 import site.practice.service.ArticleService;
-
-import java.util.List;
 
 import static site.practice.dto.ArticleSuccessCode.*;
 
@@ -42,10 +43,9 @@ public class ArticleController implements ArticleControllerDocs {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<GetArticlesResponseDto>> getArticles(){
-
-        final List<Article> articles = articleService.findArticles();
-        final GetArticlesResponseDto response = new GetArticlesResponseDto(articles);
+    public ResponseEntity<ApiResponse<GetArticlesResponseDto>> getArticles(@PageableDefault(size = 10) Pageable pageable){
+        final Slice<Article> articles = articleService.findArticles(pageable);
+        final GetArticlesResponseDto response = GetArticlesResponseDto.from(articles);
 
         return ResponseEntity.ok(
             ApiResponse.successWithData(

--- a/src/main/java/site/practice/docs/ArticleControllerDocs.java
+++ b/src/main/java/site/practice/docs/ArticleControllerDocs.java
@@ -2,6 +2,7 @@ package site.practice.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import site.practice.dto.CreateArticleRequestDto;
 import site.practice.dto.GetArticleResponseDto;
@@ -15,7 +16,7 @@ public interface ArticleControllerDocs {
     ResponseEntity<site.practice.common.response.ApiResponse<Void>> createArticle(CreateArticleRequestDto dto);
 
     @Operation(summary = "전체 게시글 조회 api")
-    ResponseEntity<site.practice.common.response.ApiResponse<GetArticlesResponseDto>> getArticles();
+    ResponseEntity<site.practice.common.response.ApiResponse<GetArticlesResponseDto>> getArticles(Pageable pageable);
 
     @Operation(summary = "게시글 조회 api")
     ResponseEntity<site.practice.common.response.ApiResponse<GetArticleResponseDto>> getAticle(Long articleId);

--- a/src/main/java/site/practice/dto/GetArticlesResponseDto.java
+++ b/src/main/java/site/practice/dto/GetArticlesResponseDto.java
@@ -1,8 +1,30 @@
 package site.practice.dto;
 
-import site.practice.entity.Article;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public record GetArticlesResponseDto(List<Article> articles) {
+public record GetArticlesResponseDto<T>(
+    List<T> articles,
+    PageInfoDto pageInfo
+) {
+    public record PageInfoDto(
+        int totalPageCount,
+        int recentPageNumber,
+        boolean hasNext,
+        int pageSize
+    ) {
+    }
+
+    public static <T> GetArticlesResponseDto<T> from(Slice<T> slice) {
+        return new GetArticlesResponseDto<>(
+            slice.getContent(),
+            new PageInfoDto(
+                slice.getPageable().getPageSize(),
+                slice.getPageable().getPageNumber(),
+                slice.hasNext(),
+                slice.getSize()
+            )
+        );
+    }
 }

--- a/src/main/java/site/practice/repository/ArticleRepository.java
+++ b/src/main/java/site/practice/repository/ArticleRepository.java
@@ -1,8 +1,10 @@
 package site.practice.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.practice.entity.Article;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-
+    Slice<Article> findAllBy(Pageable pageable);
 }

--- a/src/main/java/site/practice/service/ArticleService.java
+++ b/src/main/java/site/practice/service/ArticleService.java
@@ -2,6 +2,8 @@ package site.practice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.practice.dto.CreateArticleRequestDto;
@@ -9,8 +11,6 @@ import site.practice.dto.UpdateArticleRequestDto;
 import site.practice.entity.Article;
 import site.practice.exception.ArticleNotFoundException;
 import site.practice.repository.ArticleRepository;
-
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,8 +30,8 @@ public class ArticleService {
         articleRepository.save(article);
     }
 
-    public List<Article> findArticles() {
-        return articleRepository.findAll();
+    public Slice<Article> findArticles(Pageable pageable) {
+        return articleRepository.findAllBy(pageable);
     }
 
     public Article findArticle(Long articleId) {


### PR DESCRIPTION
### 🌱 수행 작업
- 게시글 조회 시 slice 방식을 통한 페이징 처리 추가

### 작업 소개
JPA를 활용한 페이징 처리 방식을 찾아보니 Page, Slice 두 가지 방식이 있었습니다.
두 방식의 차이점은 count 쿼리가 날라가는지 여부의 차이였습니다.

Page : 게시글 개수가 총 몇개인지 조회하기 위한 count 쿼리 발생
Slice : 게시글 전체 개수를 조회하지 않기에 count 쿼리 발생하지 않음

둘 중에 Slice 방식을 도입한 이유는 당장은 데이터가 많지 않기에 count 쿼리가 날라가도 성능에는 영향을 끼치지 않지만 추후 서비스 확장 되었을 시를 고려했습니다.
서비스 정책 상 게시글을 지울 수 없는 구조이기에 서비스 유지가 지속될 수록 수많은 데이터가 누적되어 쌓이게 됩니다. 이 경우 추후에는 count 쿼리가 발생하면 성능 문제가 발생하기에 이를 방지하고자 했습니다.

또한 게시글 조회 페이지에서 페이지 번호로 구분하는 것이 아닌 무한 스크롤이기에 클라이언트에게 게시글의 전체 개수가 필요하지 않았습니다.

이러한 점들을 고려했을 때 현재 서비스에 적합한 방식은 Slice라 생각하여 해당 방식을 사용하였습니다.